### PR TITLE
NEXUS-35492 - Allow configuring install4j vm arguments

### DIFF
--- a/nxrm-aws-resiliency/templates/deployment.yaml
+++ b/nxrm-aws-resiliency/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - name: NEXUS_SECURITY_RANDOMPASSWORD
               value: "false"
             - name: INSTALL4J_ADD_VM_PARAMS
-              value: "-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Dnexus.licenseFile=/nxrm-secrets/{{ .Values.secret.license.alias }} \
+              value: "{{ .Values.deployment.container.env.install4jAddVmParams }} -Dnexus.licenseFile=/nxrm-secrets/{{ .Values.secret.license.alias }} \
           -Dnexus.datastore.enabled=true -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs \
           -Dnexus.datastore.nexus.jdbcUrl=jdbc:postgresql://${DB_HOST}:{{ .Values.deployment.container.env.nexusDBPort }}/${DB_NAME} \
           -Dnexus.datastore.nexus.username=${DB_USER} \

--- a/nxrm-aws-resiliency/values.yaml
+++ b/nxrm-aws-resiliency/values.yaml
@@ -25,7 +25,7 @@ deployment:
     env:
       nexusDBName: nexus
       nexusDBPort: 3306
-      install4jAddVmParams: "-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m"
+      install4jAddVmParams: "-Xms2703m -Xmx2703m"
   requestLogContainer:
     image:
       repository: busybox

--- a/nxrm-aws-resiliency/values.yaml
+++ b/nxrm-aws-resiliency/values.yaml
@@ -25,6 +25,7 @@ deployment:
     env:
       nexusDBName: nexus
       nexusDBPort: 3306
+      install4jAddVmParams: "-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m"
   requestLogContainer:
     image:
       repository: busybox


### PR DESCRIPTION
I thought it made sense to leave the fields that really must be configured as concrete in the `deployment.yaml` the change should allow changing the VM arguments, and allow additional properties if needed.