### PR TITLE
INT-7432 security context for openshift

### DIFF
--- a/nexus-repository-manager/templates/deployment.yaml
+++ b/nexus-repository-manager/templates/deployment.yaml
@@ -59,7 +59,14 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           lifecycle:
           {{- if .Values.deployment.postStart.command }}
             postStart:

--- a/nexus-repository-manager/tests/deployment_test.yaml
+++ b/nexus-repository-manager/tests/deployment_test.yaml
@@ -36,7 +36,14 @@ tests:
           pattern: sonatype/nexus3:3\.\d+\.\d+
       - equal:
           path: spec.template.spec.containers[0].securityContext
-          value: null
+          value: 
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent


### PR DESCRIPTION
OpenShift wants more securityContext settings. These settings are also fine in minikube.

Reproduction:
* switch values.yaml to the red hat image: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.43.0-ubi-1
* install the chart into OpenShift Local:
```
$ helm install repo .
W1116 18:33:19.487048   52333 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "nexus-repository-manager" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "nexus-repository-manager" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "nexus-repository-manager" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "nexus-repository-manager" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

JIRA: https://issues.sonatype.org/browse/INT-7432
Build: https://jenkins.ci.sonatype.dev/job/nxrm/job/Nexus%20Repository%20Manager%203%20Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/INT-7432-securityContext-for-openshift/
