### PR TITLE
Pin helm-unittest to 0.2.11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@
 # Eclipse Foundation. All other trademarks are the property of their respective owners.
 #
 
-helm plugin install https://github.com/quintush/helm-unittest
+helm plugin install --version "0.2.11" https://github.com/quintush/helm-unittest
 
 set -e
 


### PR DESCRIPTION
Attempting to fix our helm chart build by pinning the helm-unittest version