### PR TITLE
Standardises all images used by helm chart

### DIFF
--- a/nxrm-aws-resiliency/Chart.yaml
+++ b/nxrm-aws-resiliency/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 55.0.0
+version: 55.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nxrm-aws-resiliency/templates/external-dns-rbac.yml
+++ b/nxrm-aws-resiliency/templates/external-dns-rbac.yml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: external-dns
       containers:
         - name: external-dns
-          image: k8s.gcr.io/external-dns/external-dns:v0.11.0
+          image: {{ .Values.externaldns.image.repository }}:{{ .Values.externaldns.image.tag }}
           args:
             - --source=service
             - --source=ingress

--- a/nxrm-aws-resiliency/templates/fluent-bit.yaml
+++ b/nxrm-aws-resiliency/templates/fluent-bit.yaml
@@ -264,7 +264,7 @@ spec:
     spec:
       containers:
         - name: fluent-bit
-          image: amazon/aws-for-fluent-bit:{{ .Values.deployment.fluentBitVersion }}
+          image: {{ .Values.fluentbit.container.image.repository }}:{{ .Values.fluentbit.container.image.tag }}
           imagePullPolicy: Always
           env:
             - name: AWS_REGION

--- a/nxrm-aws-resiliency/templates/workdir-daemonset.yaml
+++ b/nxrm-aws-resiliency/templates/workdir-daemonset.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
         # Copy file for creating nexus work directory over and execute it on host 
         - name: create-nexus-work-dir
-          image: ubuntu:23.04
+          image: {{ .Values.workdir.daemonset.initContainer.image.repository }}:{{ .Values.workdir.daemonset.initContainer.image.tag }}
           command: [/bin/sh]
           args:
             - -c
@@ -34,7 +34,7 @@ spec:
               mountPath: /host-dir            
       containers:
       - name: directory-creator
-        image: busybox:1.33.1
+        image: {{ .Values.workdir.daemonset.container.image.repository }}:{{ .Values.workdir.daemonset.container.image.tag }}
         command: ["/bin/sh"]
         args:
             - -c

--- a/nxrm-aws-resiliency/values.yaml
+++ b/nxrm-aws-resiliency/values.yaml
@@ -7,14 +7,20 @@ externaldns:
   enabled: false
   domainFilter: example.com #your root domain e.g example.com
   awsZoneType: private # hosted zone to look at (valid values are public, private or no value for both)
+  image:
+    repository: k8s.gcr.io/external-dns/external-dns
+    tag: v0.11.0
 fluentbit:
   enabled: false
+  container:
+    image:
+      repository: amazon/aws-for-fluent-bit
+      tag: 2.28.0
 deployment:
   clusterRegion: us-east-1
   name: nxrm.deployment
   clusterName: nxrm-nexus
   logsRegion: us-east-1
-  fluentBitVersion: 2.28.0
   replicaCount: 1
   initContainer:
     image:
@@ -71,6 +77,14 @@ workdir:
     name: create-nexus-workdir-config
   daemonset:
     name: create-nexus-work-dir
+    initContainer:
+      image:
+        repository: ubuntu
+        tag: 23.04
+    container:
+      image:
+        repository: busybox
+        tag: 1.33.1
 storageClass:
   iopsPerGB: "10" #Note: aws plugin multiplies this by the size of the requested volumne to compute IOPS of the volumne and caps it a 20, 000 IOPS
 pv:


### PR DESCRIPTION
Standardises all the image repositories and tags, such that they are all controlled via the values.yaml file.

This means its far easier to replace them if required, we have strict security requirements so all images have to come from trusted sources, this allows anyone to update the repositories as mentioned above and providers greater flexibility to the community using this helm chart.