### PR TITLE
add helm boilerplate features

### DIFF
--- a/nxrm-aws-resiliency/Chart.yaml
+++ b/nxrm-aws-resiliency/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 61.0.2
+version: 61.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nxrm-aws-resiliency/templates/_helpers.tpl
+++ b/nxrm-aws-resiliency/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nxrm-aws-resiliency.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nxrm-aws-resiliency.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nxrm-aws-resiliency.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nxrm-aws-resiliency.labels" -}}
+helm.sh/chart: {{ include "nxrm-aws-resiliency.chart" . }}
+{{ include "nxrm-aws-resiliency.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app: nxrm
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nxrm-aws-resiliency.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nxrm-aws-resiliency.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nxrm-aws-resiliency.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nxrm-aws-resiliency.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/nxrm-aws-resiliency/templates/deployment.yaml
+++ b/nxrm-aws-resiliency/templates/deployment.yaml
@@ -1,20 +1,28 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Chart.Name }}-{{ .Chart.Version }}.{{ .Release.Name }}-{{ .Values.deployment.name }}
+  name: {{ include "nxrm-aws-resiliency.fullname" . }}
   namespace: {{ .Values.namespaces.nexusNs }}
   labels:
-    app: nxrm
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nxrm
+      {{- include "nxrm-aws-resiliency.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.deployment.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        app: nxrm
+        {{- include "nxrm-aws-resiliency.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       initContainers:
         # chown nexus-data to 'nexus' user and init log directories/files for a new pod
@@ -40,8 +48,10 @@ spec:
         - name: nxrm-app
           image: {{ .Values.deployment.container.image.repository }}:{{ .Values.deployment.container.image.tag }}
           securityContext:
-            runAsUser: 200
+            {{- toYaml .Values.deployment.securityContext | nindent 12 }}
           imagePullPolicy: {{ .Values.deployment.container.pullPolicy }}
+          resources:
+            {{- toYaml .Values.deployment.resources | nindent 12 }}
           ports:
             - containerPort: {{ .Values.deployment.container.containerPort }}
           env:
@@ -70,11 +80,13 @@ spec:
             - name: NEXUS_SECURITY_RANDOMPASSWORD
               value: "false"
             - name: INSTALL4J_ADD_VM_PARAMS
-              value: "{{ .Values.deployment.container.env.install4jAddVmParams }} -Dnexus.licenseFile=/nxrm-secrets/{{ .Values.secret.license.alias }} \
-          -Dnexus.datastore.enabled=true -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs \
-          -Dnexus.datastore.nexus.jdbcUrl=jdbc:postgresql://${DB_HOST}:{{ .Values.deployment.container.env.nexusDBPort }}/${DB_NAME} \
-          -Dnexus.datastore.nexus.username=${DB_USER} \
-          -Dnexus.datastore.nexus.password=${DB_PASSWORD}"
+              value: >-
+                {{ .Values.deployment.container.env.install4jAddVmParams }} 
+                -Dnexus.licenseFile=/nxrm-secrets/{{ .Values.secret.license.alias }}
+                -Dnexus.datastore.enabled=true -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs
+                -Dnexus.datastore.nexus.jdbcUrl=jdbc:postgresql://${DB_HOST}:{{ .Values.deployment.container.env.nexusDBPort }}/${DB_NAME}
+                -Dnexus.datastore.nexus.username=${DB_USER}
+                -Dnexus.datastore.nexus.password=${DB_PASSWORD}
           volumeMounts:
             - mountPath: /nxrm-secrets
               name: nxrm-secrets
@@ -118,3 +130,15 @@ spec:
             items:
               - key: logback-tasklogfile-appender-override.xml
                 path: logback-tasklogfile-appender-override.xml
+      {{- with .Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/nxrm-aws-resiliency/templates/ingress.yaml
+++ b/nxrm-aws-resiliency/templates/ingress.yaml
@@ -2,11 +2,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: {{ .Values.namespaces.nexusNs }}
-  name: {{ .Chart.Name }}-{{ .Chart.Version }}.{{ .Release.Name }}-ingress
+  name: {{ include "nxrm-aws-resiliency.fullname" . }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  labels:
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 spec:
   rules:
     {{- if .Values.ingress.host }}
@@ -20,7 +22,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ .Chart.Name }}-service
+                name: {{ include "nxrm-aws-resiliency.fullname" . }}
                 port:
                   number: {{ .Values.service.nexus.port }}
 ---
@@ -29,11 +31,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: {{ .Values.namespaces.nexusNs }}
-  name: {{ .Chart.Name }}-{{ .Chart.Version }}.{{ .Release.Name }}-ingress-nxrm-docker
+  name: {{ include "nxrm-aws-resiliency.fullname" . }}-docker
   {{- with .Values.ingress.dockerIngress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  labels:
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 spec:
   rules:
     {{- if .Values.ingress.dockerIngress.host }}
@@ -47,7 +51,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ .Chart.Name }}-docker-service
+                name: {{ include "nxrm-aws-resiliency.fullname" . }}-docker
                 port:
                   number: {{ .Values.service.docker.port }}
 {{- end }}

--- a/nxrm-aws-resiliency/templates/pv.yaml
+++ b/nxrm-aws-resiliency/templates/pv.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Chart.Name }}-{{ .Chart.Version }}.{{ .Release.Name }}-ebs-pv
+  name: {{ include "nxrm-aws-resiliency.fullname" . }}
+  labels:
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 spec:
   capacity:
     storage: {{ .Values.pv.storage }}
@@ -9,7 +11,7 @@ spec:
   accessModes:
   - {{ .Values.pv.accessModes }}
   persistentVolumeReclaimPolicy: {{ .Values.pv.reclaimPolicy }}
-  storageClassName: local-storage
+  storageClassName: {{ include "nxrm-aws-resiliency.fullname" . }}-local-storage
   local:
     path: {{ .Values.pv.path }}
   nodeAffinity:
@@ -22,7 +24,3 @@ spec:
           {{- range $zone  := .Values.pv.zones }}
           - {{ $zone }} 
           {{- end }}  
-
-          
-          
-         

--- a/nxrm-aws-resiliency/templates/pvc.yaml
+++ b/nxrm-aws-resiliency/templates/pvc.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Chart.Name }}-{{ .Chart.Version }}.{{ .Release.Name }}-ebs-claim
+  name: {{ include "nxrm-aws-resiliency.fullname" . }}
   namespace: {{ .Values.namespaces.nexusNs }}
+  labels:
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.pvc.accessModes }}

--- a/nxrm-aws-resiliency/templates/secret.yaml
+++ b/nxrm-aws-resiliency/templates/secret.yaml
@@ -2,7 +2,9 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   namespace: {{ .Values.namespaces.nexusNs }}
-  name: {{ .Chart.Name }}-{{ .Chart.Version }}.{{ .Release.Name }}-secret
+  name: {{ include "nxrm-aws-resiliency.fullname" . }}
+  labels:
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 spec:
   provider: aws
   secretObjects:

--- a/nxrm-aws-resiliency/templates/serviceaccount.yaml
+++ b/nxrm-aws-resiliency/templates/serviceaccount.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.namespaces.nexusNs }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.role }}
+  labels:
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 ---
 {{- if .Values.externaldns.enabled }}
 apiVersion: v1
@@ -14,4 +16,6 @@ metadata:
   namespace: {{ .Values.namespaces.externaldnsNs }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.externaldns.role }}
+  labels:
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 {{- end }}

--- a/nxrm-aws-resiliency/templates/services.yaml
+++ b/nxrm-aws-resiliency/templates/services.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}-service
+  name: {{ include "nxrm-aws-resiliency.fullname" . }}
   namespace: {{ .Values.namespaces.nexusNs }}
   labels:
-    app: nxrm
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.nexus.type }}
   selector:
-    app: nxrm
+    {{- include "nxrm-aws-resiliency.selectorLabels" . | nindent 4 }}
   ports:
     - protocol: {{ .Values.service.nexus.protocol }}
       port: {{ .Values.service.nexus.port }}
@@ -18,14 +18,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}-docker-service
+  name: {{ include "nxrm-aws-resiliency.fullname" . }}-docker
   namespace: {{ .Values.namespaces.nexusNs }}
   labels:
-    app: nxrm
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 spec:
   type:  {{ .Values.service.docker.type }}
   selector:
-    app: nxrm
+    {{- include "nxrm-aws-resiliency.selectorLabels" . | nindent 4 }}
   ports:
     - name: docker-service
       protocol: {{ .Values.service.docker.protocol }}

--- a/nxrm-aws-resiliency/templates/storageclass.yaml
+++ b/nxrm-aws-resiliency/templates/storageclass.yaml
@@ -1,7 +1,9 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ .Chart.Name }}-{{ .Chart.Version }}.{{ .Release.Name }}-local-storage
+  name: {{ include "nxrm-aws-resiliency.fullname" . }}-local-storage
   namespace: {{ .Values.namespaces.nexusNs }}
+  labels:
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer

--- a/nxrm-aws-resiliency/templates/workdir-configmap.yaml
+++ b/nxrm-aws-resiliency/templates/workdir-configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.workdir.configmap.name }}
   namespace: {{ .Values.namespaces.nexusNs }}
+  labels:
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 data:
    create-nexus-work-dir.sh: |
     #!/bin/bash

--- a/nxrm-aws-resiliency/templates/workdir-daemonset.yaml
+++ b/nxrm-aws-resiliency/templates/workdir-daemonset.yaml
@@ -3,6 +3,8 @@ kind: DaemonSet
 metadata:
   name:  {{ .Values.workdir.daemonset.name }}
   namespace: {{ .Values.namespaces.nexusNs }}
+  labels:
+    {{- include "nxrm-aws-resiliency.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/nxrm-aws-resiliency/values.yaml
+++ b/nxrm-aws-resiliency/values.yaml
@@ -42,6 +42,14 @@ deployment:
     image:
       repository: busybox
       tag: 1.33.1
+  resources: {}
+  podAnnotations: {}
+  imagePullSecrets: []
+  securityContext:
+    runAsUser: 200
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 serviceAccount:
   name: nexus-repository-deployment-sa #This SA is created as part of steps under "AWS Secrets Manager"
   role: arn:aws:iam::000000000000:role/nxrm-nexus-role #Role with secretsmanager permissions


### PR DESCRIPTION
Provide options mentioned in sonatype/nxrm3-helm-repository/issues/56
This version of the chart is not backwards compatible with previous versions, because service selectors are immutable. Also, all of the resources have been renamed, bringing them inline with typical helm chart resource naming conventions.

- follow resource naming conventions in community charts
- templates/_helpers.tpl includes a lot of helpful functions... chief among them resource name length controls
  - [well known labels](https://kubernetes.io/docs/reference/labels-annotations-taints/)
  - label all resources using well known labels
  - fullname and name overrides
- [resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/): Optionally allow the scheduler to guarantee [quality of service](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/).
- [imagePullSecrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/): Optionally specify pull secrets
- [podAnnotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
- [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)
- [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) 
- [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)