### PR TITLE
fix: Fix YAML scalar block type

### DIFF
--- a/nexus-repository-manager/tests/deployment_test.yaml
+++ b/nexus-repository-manager/tests/deployment_test.yaml
@@ -51,7 +51,7 @@ tests:
           path: spec.template.spec.containers[0].env
           value:
             - name: INSTALL4J_ADD_VM_PARAMS
-              value: |-
+              value: >-
                 -Xms2703M -Xmx2703M
                 -XX:MaxDirectMemorySize=2703M
                 -XX:+UnlockExperimentalVMOptions

--- a/nexus-repository-manager/values.yaml
+++ b/nexus-repository-manager/values.yaml
@@ -24,7 +24,7 @@ nexus:
     # minimum recommended memory settings for a small, person instance from
     # https://help.sonatype.com/repomanager3/product-information/system-requirements
     - name: INSTALL4J_ADD_VM_PARAMS
-      value: |-
+      value: >-
         -Xms2703M -Xmx2703M
         -XX:MaxDirectMemorySize=2703M
         -XX:+UnlockExperimentalVMOptions


### PR DESCRIPTION
`|-` renders newlines from YAML definition which is breaking the java options, replace with `>-` which strips the additional newlines